### PR TITLE
Implement email behaviour

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,5 @@
+extends:
+- "homeoffice/config/default"
+
+env:
+  es6: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "6"
+  - "4"
+
+before_install:
+  - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # hof-behaviour-emailer
 HOF behaviour to send emails
+
+## Usage
+
+```js
+const EmailBehaviour = require('hof-behaviour-emailer');
+
+// configure email behaviour
+const emailer = EmailBehaviour({
+  transport: 'ses',
+  transportOptions: {
+    accessKeyId: '...',
+    secretAccessKey: '...'
+  },
+  template: path.resolve(__dirname, './views/emails/confirm.html'),
+  from: 'confirmation@homeoffice.gov.uk',
+  recipient: 'customer-email',
+  subject: 'Application Successful'
+});
+
+// in steps config
+steps: {
+  ...
+  '/confirm': {
+    behaviours: ['complete', emailer],
+    next: '/confirmation',
+    ...
+  },
+  ...
+}
+```

--- a/README.md
+++ b/README.md
@@ -30,3 +30,14 @@ steps: {
   ...
 }
 ```
+
+## Options
+
+In addition to the options passed to `hof-emailer`, the following options can be used:
+
+* `recipient` - _Required_ - defines the address to which email will be sent. This can be set either as a key to retrieve an email address from the session, or explicitly to an email address.
+* `template` - _Required_ - defines the mustache template used to render the email content.
+* `subject` - defines the subject line of the email.
+* `parse` - parses the session model into an object used to populate the template.
+
+`recipient` and `subject` options can also be defined as functions, which will be passed a copy of the session model as an argument, and should return a string value.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+'use strict';
+module.exports = require('./lib/emailer');

--- a/lib/emailer.js
+++ b/lib/emailer.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = config => {
+  return superclass => class Emailer extends superclass {
+
+    saveValues(req, res, callback) {
+      super.saveValues(req, res, callback);
+    }
+
+  };
+};

--- a/lib/emailer.js
+++ b/lib/emailer.js
@@ -1,10 +1,56 @@
 'use strict';
 
+const Emailer = require('hof-emailer');
+const Hogan = require('hogan.js');
+const fs = require('fs');
+const debug = require('debug')('hof:behaviour:emailer');
+
 module.exports = config => {
-  return superclass => class Emailer extends superclass {
+
+  const emailer = new Emailer(config);
+  config.parse = config.parse || (data => data);
+
+  return superclass => class EmailBehaviour extends superclass {
 
     saveValues(req, res, callback) {
-      super.saveValues(req, res, callback);
+      Promise.resolve()
+        .then(() => {
+          debug(`Loading email template from ${config.template}`);
+          return new Promise((resolve, reject) => {
+            fs.readFile(config.template, (err, template) => {
+              return err ? reject(err) : resolve(template.toString('utf8'));
+            });
+          });
+        })
+        .then(template => {
+          debug('Rendering email content');
+          const data = config.parse(req.sessionModel.toJSON());
+          return Hogan.compile(template).render(data);
+        })
+        .then(body => {
+          debug('Building email settings');
+          const settings = { body };
+          if (typeof config.recipient === 'string') {
+            settings.recipient = req.sessionModel.get(config.recipient) || config.recipient;
+          } else if (typeof config.recipient === 'function') {
+            settings.recipient = config.recipient(req.sessionModel.toJSON());
+          }
+          if (typeof config.subject === 'string') {
+            settings.subject = config.subject;
+          } else if (typeof config.subject === 'function') {
+            settings.subject = config.subject(req.sessionModel.toJSON());
+          }
+          return settings;
+        })
+        .then(settings => {
+          debug('Sending email', settings);
+          return emailer.send(settings);
+        })
+        .then(() => {
+          debug('Email sent successfully');
+          super.saveValues(req, res, callback);
+        }, callback);
+
     }
 
   };

--- a/lib/emailer.js
+++ b/lib/emailer.js
@@ -10,6 +10,13 @@ module.exports = config => {
   const emailer = new Emailer(config);
   config.parse = config.parse || (data => data);
 
+  if (!config.recipient) {
+    throw new Error('hof-behaviour-emailer: email recipient must be defined');
+  }
+  if (typeof config.template !== 'string') {
+    throw new Error('hof-behaviour-emailer: email template must be defined');
+  }
+
   return superclass => class EmailBehaviour extends superclass {
 
     saveValues(req, res, callback) {
@@ -50,7 +57,6 @@ module.exports = config => {
           debug('Email sent successfully');
           super.saveValues(req, res, callback);
         }, callback);
-
     }
 
   };

--- a/lib/emailer.js
+++ b/lib/emailer.js
@@ -37,16 +37,22 @@ module.exports = config => {
         .then(body => {
           debug('Building email settings');
           const settings = { body };
-          if (typeof config.recipient === 'string') {
-            settings.recipient = req.sessionModel.get(config.recipient) || config.recipient;
-          } else if (typeof config.recipient === 'function') {
+
+          if (typeof config.recipient === 'function') {
             settings.recipient = config.recipient(req.sessionModel.toJSON());
+          } else {
+            settings.recipient = req.sessionModel.get(config.recipient) || config.recipient;
           }
-          if (typeof config.subject === 'string') {
-            settings.subject = config.subject;
-          } else if (typeof config.subject === 'function') {
+          if (typeof settings.recipient !== 'string' || !settings.recipient.includes('@')) {
+            throw new Error('hof-behaviour-emailer: invalid recipient');
+          }
+
+          if (typeof config.subject === 'function') {
             settings.subject = config.subject(req.sessionModel.toJSON());
+          } else {
+            settings.subject = config.subject;
           }
+
           return settings;
         })
         .then(settings => {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "npm run test:lint && npm run test:unit",
     "test:lint": "eslint .",
-    "test:unit": "mocha"
+    "test:unit": "mocha",
+    "test:unit:cover": "istanbul cover _mocha"
   },
   "repository": {
     "type": "git",
@@ -31,6 +32,11 @@
     "chai": "^3.5.0",
     "eslint": "^3.17.1",
     "eslint-config-homeoffice": "^2.1.2",
-    "mocha": "^3.2.0"
+    "hof-util-reqres": "^1.0.0",
+    "istanbul": "^0.4.5",
+    "mocha": "^3.2.0",
+    "mocha-sandbox": "^1.0.0",
+    "sinon": "^1.17.7",
+    "sinon-chai": "^2.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
     "hof-behaviour"
   ],
   "homepage": "https://github.com/UKHomeOfficeForms/hof-behaviour-emailer#readme",
+  "dependencies": {
+    "debug": "^2.6.1",
+    "hof-emailer": "^2.0.0",
+    "hogan.js": "^3.0.2"
+  },
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^3.17.1",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "hof-behaviour-emailer",
+  "version": "1.0.0",
+  "description": "HOF behaviour to send emails",
+  "main": "index.js",
+  "scripts": {
+    "test": "npm run test:lint && npm run test:unit",
+    "test:lint": "eslint .",
+    "test:unit": "mocha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/UKHomeOfficeForms/hof-behaviour-emailer.git"
+  },
+  "author": "Leonard Martin <hello@lennym.co.uk>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/UKHomeOfficeForms/hof-behaviour-emailer/issues"
+  },
+  "keywords": [
+    "hof",
+    "hof-behaviour"
+  ],
+  "homepage": "https://github.com/UKHomeOfficeForms/hof-behaviour-emailer#readme",
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "eslint": "^3.17.1",
+    "eslint-config-homeoffice": "^2.1.2",
+    "mocha": "^3.2.0"
+  }
+}

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,6 @@
+extends:
+  - '../.eslintrc'
+  - 'homeoffice/config/testing'
+
+env:
+  es6: true

--- a/test/index.js
+++ b/test/index.js
@@ -124,6 +124,36 @@ describe('Emailer Behaviour', () => {
       }, done));
     });
 
+    it('throws error if recipient does not resolve to a string', done => {
+      const opts = options({ recipient: data => `${data.name}@example.com` });
+      const Email = Behaviour(opts)(Base);
+      controller = new Email();
+      req.sessionModel.set('name', 'bob');
+      controller.saveValues(req, {}, sandbox(err => {
+        expect(err).not.to.exist;
+      }, done));
+    });
+
+    it('throws error if recipient resolves to a null value', done => {
+      const opts = options({ recipient: 'unknown-field' });
+      req.sessionModel.unset('unknown-field');
+      const Email = Behaviour(opts)(Base);
+      controller = new Email();
+      controller.saveValues(req, {}, sandbox(err => {
+        expect(err).to.be.an('error');
+      }, done));
+    });
+
+    it('throws error if recipient resolves to a string that is not an email address', done => {
+      const opts = options({ recipient: 'name' });
+      req.sessionModel.set('name', 'Alice');
+      const Email = Behaviour(opts)(Base);
+      controller = new Email();
+      controller.saveValues(req, {}, sandbox(err => {
+        expect(err).to.be.an('error');
+      }, done));
+    });
+
     it('sends an email with a body of a rendered template', done => {
       req.sessionModel.set('name', 'Alice');
       controller.saveValues(req, {}, sandbox(err => {

--- a/test/index.js
+++ b/test/index.js
@@ -1,19 +1,177 @@
 'use strict';
 
-const expect = require('chai').expect;
+const sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+const sandbox = require('mocha-sandbox');
+const request = require('hof-util-reqres').req;
+
+chai.use(require('sinon-chai'));
 
 const Behaviour = require('../');
 
+const fs = require('fs');
+const Emailer = require('hof-emailer');
+
+// helper to avoid having to define full options every time
+const options = (opts) => {
+  return Object.assign({
+    transport: 'stub',
+    recipient: 'test@example.com',
+    subject: 'confirmation email',
+    template: '/path/to/to/my/email/template.html'
+  }, opts);
+};
+
 describe('Emailer Behaviour', () => {
+
+  beforeEach(() => {
+    sinon.stub(fs, 'readFile').withArgs('/path/to/to/my/email/template.html').yieldsAsync(null, 'hello {{name}}');
+    sinon.stub(Emailer.prototype, 'send').returns(Promise.resolve());
+  });
+
+  afterEach(() => {
+    fs.readFile.restore();
+    Emailer.prototype.send.restore();
+  });
 
   it('exports a function', () => {
     expect(Behaviour).to.be.a('function');
   });
 
-  it('returns a mixin', () => {
-    class Base {}
-    const Mixed = Behaviour()(Base);
-    expect(new Mixed()).to.be.an.instanceOf(Base);
+  describe('initialisation', () => {
+
+    const make = (opts) => {
+      return Behaviour(options(opts))(class {});
+    };
+
+    it('returns a mixin', () => {
+      const opts = options({ recipient: 'test@example.com' });
+      class Base {}
+      const Mixed = Behaviour(opts)(Base);
+      expect(new Mixed()).to.be.an.instanceOf(Base);
+    });
+
+    it('errors if no recipient is set', () => {
+      expect(() => make({ recipient: null })).to.throw();
+    });
+
+    it('errors if no template is set', () => {
+      expect(() => make({ template: null })).to.throw();
+    });
+
+  });
+
+  describe('saveValues', () => {
+
+    class Base {
+      saveValues() {}
+    }
+
+    let controller;
+    let req;
+
+    beforeEach(() => {
+      sinon.stub(Base.prototype, 'saveValues').yieldsAsync();
+      const Email = Behaviour(options())(Base);
+      controller = new Email();
+      req = request();
+    });
+
+    afterEach(() => {
+      Base.prototype.saveValues.restore();
+    });
+
+    it('exists, and is a function', () => {
+      const Mixed = Behaviour(options())(class {});
+      const instance = new Mixed();
+      expect(instance).to.have.property('saveValues');
+      expect(instance.saveValues).to.be.a('function');
+    });
+
+    it('sends an email to the configured recipient', done => {
+      controller.saveValues(req, {}, sandbox(err => {
+        expect(err).not.to.exist;
+        expect(Emailer.prototype.send).to.have.been.calledWith(sinon.match({
+          recipient: 'test@example.com'
+        }));
+      }, done));
+    });
+
+    it('loads the recipient address from the session model if configured with a key', done => {
+      const opts = options({ recipient: 'user-email' });
+      const Email = Behaviour(opts)(Base);
+      controller = new Email();
+      req.sessionModel.set('user-email', 'user@example.com');
+      controller.saveValues(req, {}, sandbox(err => {
+        expect(err).not.to.exist;
+        expect(Emailer.prototype.send).to.have.been.calledWith(sinon.match({
+          recipient: 'user@example.com'
+        }));
+      }, done));
+    });
+
+    it('loads the recipient address from a function if passed', done => {
+      const opts = options({ recipient: data => `${data.name}@example.com` });
+      const Email = Behaviour(opts)(Base);
+      controller = new Email();
+      req.sessionModel.set('name', 'bob');
+      controller.saveValues(req, {}, sandbox(err => {
+        expect(err).not.to.exist;
+        expect(Emailer.prototype.send).to.have.been.calledWith(sinon.match({
+          recipient: 'bob@example.com'
+        }));
+      }, done));
+    });
+
+    it('sends an email with a body of a rendered template', done => {
+      req.sessionModel.set('name', 'Alice');
+      controller.saveValues(req, {}, sandbox(err => {
+        expect(err).not.to.exist;
+        expect(Emailer.prototype.send).to.have.been.calledWith(sinon.match({
+          body: 'hello Alice'
+        }));
+      }, done));
+    });
+
+    it('sends an email with the configured subject', done => {
+      controller.saveValues(req, {}, sandbox(err => {
+        expect(err).not.to.exist;
+        expect(Emailer.prototype.send).to.have.been.calledWith(sinon.match({
+          subject: 'confirmation email'
+        }));
+      }, done));
+    });
+
+    it('loads the subject from a function if passed', done => {
+      const opts = options({ subject: data => `application for ${data.name}` });
+      const Email = Behaviour(opts)(Base);
+      controller = new Email();
+      req.sessionModel.set('name', 'bob');
+      controller.saveValues(req, {}, sandbox(err => {
+        expect(err).not.to.exist;
+        expect(Emailer.prototype.send).to.have.been.calledWith(sinon.match({
+          subject: 'application for bob'
+        }));
+      }, done));
+    });
+
+    it('calls through to super.saveValues when complete', done => {
+      controller.saveValues(req, {}, sandbox(err => {
+        expect(err).not.to.exist;
+        expect(Base.prototype.saveValues).to.have.been.calledWith(req, {});
+        expect(Base.prototype.saveValues).to.have.been.calledAfter(Emailer.prototype.send);
+      }, done));
+    });
+
+    it('calls back with error if template cannot be loaded', done => {
+      const err = new Error('readfile failed');
+      fs.readFile.withArgs('/path/to/to/my/email/template.html').yieldsAsync(err);
+      controller.saveValues(req, {}, sandbox(e => {
+        expect(e).to.equal(err);
+      }, done));
+    });
+
   });
 
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const expect = require('chai').expect;
+
+const Behaviour = require('../');
+
+describe('Emailer Behaviour', () => {
+
+  it('exports a function', () => {
+    expect(Behaviour).to.be.a('function');
+  });
+
+  it('returns a mixin', () => {
+    class Base {}
+    const Mixed = Behaviour()(Base);
+    expect(new Mixed()).to.be.an.instanceOf(Base);
+  });
+
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--recursive


### PR DESCRIPTION
Adds a behaviour that be configured to send emails based on html (or text, it don't care) templates to arbitrary recipients.

Recipient addresses can either be pulled from the session model for applicants/users, or hard-coded for case-workers.

## Usage

```js
const EmailBehaviour = require('hof-behaviour-emailer');

// configure email behaviour
const emailer = EmailBehaviour({
  transport: 'ses',
  transportOptions: {
    accessKeyId: '...',
    secretAccessKey: '...'
  },
  template: path.resolve(__dirname, './views/emails/confirm.html'),
  from: 'confirmation@homeoffice.gov.uk',
  recipient: 'customer-email',
  subject: 'Application Successful'
});

// in steps config
steps: {
  ...
  '/confirm': {
    behaviours: ['complete', emailer],
    next: '/confirmation',
    ...
  },
  ...
}
```