### PR TITLE
Pass `req.translate` to `parse` and `subject` functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,12 @@ In addition to the options passed to `hof-emailer`, the following options can be
 * `subject` - defines the subject line of the email.
 * `parse` - parses the session model into an object used to populate the template.
 
-`recipient` and `subject` options can also be defined as functions, which will be passed a copy of the session model as an argument, and should return a string value.
+`recipient` and `subject` options can also be defined as functions, which will be passed a copy of the session model and a translation function as arguments, and should return a string value.
+
+```js
+// use a translated value for the email subject line
+const emailer = EmailBehaviour({
+  // ...
+  subject: (model, translate) => translate('email.success.subject')
+});
+```

--- a/lib/emailer.js
+++ b/lib/emailer.js
@@ -31,7 +31,7 @@ module.exports = config => {
         })
         .then(template => {
           debug('Rendering email content');
-          const data = config.parse(req.sessionModel.toJSON());
+          const data = config.parse(req.sessionModel.toJSON(), req.translate);
           return Hogan.compile(template).render(data);
         })
         .then(body => {
@@ -48,7 +48,7 @@ module.exports = config => {
           }
 
           if (typeof config.subject === 'function') {
-            settings.subject = config.subject(req.sessionModel.toJSON());
+            settings.subject = config.subject(req.sessionModel.toJSON(), req.translate);
           } else {
             settings.subject = config.subject;
           }


### PR DESCRIPTION
This allows emails to contain dynamic language-based content